### PR TITLE
Show cover image in hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
     <header class="hero">
         <div class="hero-content">
-            <div class="ebook-mockup"></div>
+            <img src="public/cover.png" alt="ChatGPT for Growth eBook cover" class="ebook-mockup" />
             <div class="hero-text">
                 <h1>Work Less, Earn More, Achieve More with ChatGPT.</h1>
                 <p>Leverage AI to accelerate your productivity, income, and personal growth.</p>

--- a/style.css
+++ b/style.css
@@ -25,10 +25,11 @@ body {
 .ebook-mockup {
     width: 300px;
     height: 420px;
-    background: linear-gradient(135deg, #ffffff, #e5e7eb);
     border-radius: 12px;
     box-shadow: 0 20px 40px rgba(0,0,0,0.2);
     transform: perspective(1000px) rotateY(-20deg);
+    object-fit: cover;
+    display: block;
 }
 
 .hero-text {


### PR DESCRIPTION
## Summary
- Display `public/cover.png` in hero section as book cover
- Style cover image with perspective and shadow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb025429c88332b63b01c24d7bb797